### PR TITLE
Fix for SwitchParameter TerminatingError

### DIFF
--- a/pso2_winstore_fix.ps1
+++ b/pso2_winstore_fix.ps1
@@ -1653,12 +1653,12 @@ $JSONPath = Join-Path -Path $JSONFolder -ChildPath "settings.json"
 
 If (-Not (Test-Path -LiteralPath $JSONFolder -PathType Container))
 {
-	New-Item -Path $JSONFolder -ItemType Directory -Force -Confirm:False -Verbose | Out-Null
+	New-Item -Path $JSONFolder -ItemType Directory -Force -Confirm:$false -Verbose | Out-Null
 }
 
 If (-Not (Test-Path -LiteralPath $JSONPath -PathType Leaf))
 {
-	New-Item -Path $JSONFolder -ItemType Directory -Force -Confirm:$False -Verbose | Out-Null
+	New-Item -Path $JSONFolder -ItemType Directory -Force -Confirm:$false -Verbose | Out-Null
 }
 
 Write-Host -Object "Checking for existing PSO2NA package..."


### PR DESCRIPTION
    PS>TerminatingError(New-Item): "Cannot convert 'System.String' to the type 'System.Management.Automation.SwitchParameter' required by parameter 'Confirm'. "
    >> TerminatingError(New-Item): "Cannot convert 'System.String' to the type 'System.Management.Automation.SwitchParameter' required by parameter 'Confirm'. "
    Cannot convert 'System.String' to the type 'System.Management.Automation.SwitchParameter' required by parameter 'Confirm'.
    New-Item : Cannot convert 'System.String' to the type 'System.Management.Automation.SwitchParameter' required by parameter 'Confirm'.
    At C:\Program Files (x86)\PSO tweaker\pso2_winstore_fix.ps1:1655 char:65
    + ... m -Path $JSONFolder -ItemType Directory -Force -Confirm:False -Verbos ...
    +                                                             ~~~~~
        + CategoryInfo          : InvalidArgument: (:) [New-Item], ParentContainsErrorRecordException
        + FullyQualifiedErrorId : CannotConvertArgument,Microsoft.PowerShell.Commands.NewItemCommand

Future points: investigate `$ConfirmPreference = “None”`